### PR TITLE
feat: darken navigation background

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 
     /* ===== nav / header ===== */
     header{position:sticky; top:0; z-index:40}
-    .nav{position:relative; min-height:var(--header-h); height:auto; margin:10px auto; padding:10px 14px 12px; display:flex; flex-wrap:wrap; gap:12px; align-items:center; align-content:center; justify-content:space-between}
+    .nav{position:relative; min-height:var(--header-h); height:auto; margin:10px auto; padding:10px 14px 12px; display:flex; flex-wrap:wrap; gap:12px; align-items:center; align-content:center; justify-content:space-between; background:rgba(11,15,26,.8)}
     .brand{display:flex; gap:10px; align-items:center; min-width:0}
     .brand .dot{width:10px; height:10px; border-radius:50%; background:linear-gradient(90deg,var(--accent1),var(--accent2))}
     .brand span{font-weight:700; letter-spacing:.3px; font-size:clamp(16px,2.8vw,18px); line-height:1.1}
@@ -118,7 +118,7 @@
       .nav{gap:8px}
       .links{display:none}
       .nav-toggle{display:inline-flex}
-      .nav.open .links{display:grid; grid-template-columns:1fr 1fr; gap:8px; position:absolute; top:calc(100% + 8px); left:8px; right:8px; padding:10px; border-radius:20px; background:var(--glass); backdrop-filter:saturate(140%) blur(20px); -webkit-backdrop-filter:saturate(140%) blur(20px); border:1px solid var(--border)}
+      .nav.open .links{display:grid; grid-template-columns:1fr 1fr; gap:8px; position:absolute; top:calc(100% + 8px); left:8px; right:8px; padding:10px; border-radius:20px; background:rgba(11,15,26,.9); backdrop-filter:saturate(140%) blur(20px); -webkit-backdrop-filter:saturate(140%) blur(20px); border:1px solid var(--border)}
       .links a{padding:12px 14px}
       .portrait{order:-1}
     }


### PR DESCRIPTION
## Summary
- darken navigation bar for better readability
- darken mobile dropdown menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b01062c2148331825b533c3c93f8f2